### PR TITLE
Correct KraaijevangerSpijker order from 2 to 1

### DIFF
--- a/src/tableaus/dirk.jl
+++ b/src/tableaus/dirk.jl
@@ -39,7 +39,7 @@ Reference:
 """
 
 """
-Tableau of Kraaijevanger and Spijker's two-stage, 2nd order method
+Tableau of Kraaijevanger and Spijker's two-stage, 1st order method
 
 ```julia
 TableauKraaijevangerSpijker(::Type{T}=Float64) where {T}
@@ -53,7 +53,7 @@ function TableauKraaijevangerSpijker(::Type{T}=Float64) where {T}
               [-1/2   2   ]]
     b = @big  [-1/2,  3/2 ]
     c = @big  [ 1/2,  3/2 ]
-    o = 2
+    o = 1
 
     Tableau{T}(:KraaijevangerSpijker, o, a, b, c)
 end

--- a/test/test_tableaus.jl
+++ b/test/test_tableaus.jl
@@ -133,7 +133,7 @@ end
     @test !isfullyimplicit(TableauCrouzeix())
     
     @test typeof(TableauKraaijevangerSpijker()) <: Tableau
-    @test order(TableauKraaijevangerSpijker()) == 2
+    @test order(TableauKraaijevangerSpijker()) == 1
     @test nstages(TableauKraaijevangerSpijker()) == 2
     @test reference(TableauKraaijevangerSpijker()) == reference(Val(:KraaijevangerSpijker))
 


### PR DESCRIPTION
## Summary

The `TableauKraaijevangerSpijker` tableau was declared as 2nd order, but it is actually only 1st order.

- **Coefficients are correct** and match the literature (Kraaijevanger & Spijker, *Appl. Numer. Math.* 5 (1989) 71–87; also the Wikipedia/HandWiki "List of Runge–Kutta methods"): `c = [1/2, 3/2]`, `A = [[1/2, 0], [-1/2, 2]]`, `b = [-1/2, 3/2]`.
- **The order label was wrong.** Checking the Butcher order conditions:
  - Order 1: `sum(b) = -1/2 + 3/2 = 1` ✓
  - Order 2: `sum(b.*c) = (-1/2)(1/2) + (3/2)(3/2) = 2`, but requires `1/2` ✗ (residual 3/2 — not rounding)

Neither Wikipedia nor HandWiki assign this method an order; it is listed among DIRK methods for its algebraic-stability / error-propagation significance (the subject of the 1989 paper), not accuracy. The label was likely inherited from grouping it with the neighbouring order-2 two-stage methods (CrankNicolson, QinZhang).

## Changes

- `src/tableaus/dirk.jl`: `o = 2` → `o = 1`, and docstring "2nd order" → "1st order"
- `test/test_tableaus.jl`: `order(TableauKraaijevangerSpijker()) == 2` → `== 1`

The numerical coefficients are unchanged.

## Testing

`Pkg.test()` passes, including the independent "Order Conditions" suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)