### PR TITLE
Add the two-stage, 3rd order fully implicit tableau IRK3

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The following tableaus are implemented (prepend `Tableau` to the name to call th
 
 - *diagonally implicit*: CrankNicolson, Crouzeix, KraaijevangerSpijker, QinZhang
 
-- *fully implicit*: ImplicitEuler/BackwardEuler, ImplicitMidpoint, SRK3
+- *fully implicit*: ImplicitEuler/BackwardEuler, ImplicitMidpoint, IRK3, SRK3
 
 In addition there exist functions to compute Gauss, Lobatto and Radau tableaus with an arbitrary number of stages s:
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -45,7 +45,7 @@ The following tableaus are implemented (prepend `Tableau` to the name to call th
 
 - *diagonally implicit*: CrankNicolson, Crouzeix, KraaijevangerSpijker, QinZhang
 
-- *fully implicit*: ImplicitEuler/BackwardEuler, ImplicitMidpoint, SRK3
+- *fully implicit*: ImplicitEuler/BackwardEuler, ImplicitMidpoint, IRK3, SRK3
 
 In addition there exist functions to compute Gauss, Lobatto and Radau tableaus with an arbitrary number of stages s:
 

--- a/docs/src/methods.md
+++ b/docs/src/methods.md
@@ -43,6 +43,7 @@ All constructors take an optional type argument, defaulting to `Float64`.
 |:---------------------------------------------------------------|:-------|:------|
 | [`TableauImplicitEuler`](@ref), [`TableauBackwardEuler`](@ref) | 1      | 1     |
 | [`TableauImplicitMidpoint`](@ref)                              | 2      | 2     |
+| [`TableauIRK3`](@ref)                                          | 2      | 3     |
 | [`TableauSRK3`](@ref)                                          | 3      | 4     |
 
 ## Gauß, Lobatto and Radau Methods

--- a/src/Tableaus.jl
+++ b/src/Tableaus.jl
@@ -42,6 +42,7 @@ module Tableaus
 
     export TableauImplicitEuler, TableauBackwardEuler,
            TableauImplicitMidpoint,
+           TableauIRK3,
            TableauSRK3
 
     include("tableaus/gauss.jl")
@@ -107,6 +108,7 @@ module Tableaus
        backward_euler        = TableauBackwardEuler,
        implicit_euler        = TableauImplicitEuler,
        implicit_midpoint     = TableauImplicitMidpoint,
+       irk3                  = TableauIRK3,
        srk3                  = TableauSRK3,
     )
 

--- a/src/tableaus/firk.jl
+++ b/src/tableaus/firk.jl
@@ -61,6 +61,43 @@ function TableauImplicitMidpoint(::Type{T}=Float64) where {T}
 end
 
 
+reference(::Val{:IRK3}) = """
+Reference:
+
+    Ernst Hairer and Gerhard Wanner.
+    Solving Ordinary Differential Equations II: Stiff and Differential-Algebraic Problems.
+    Springer, 1996.
+    Section IV.5, W-transformation.
+    The s=2, γ=1/2 member of the family of algebraically stable methods of order 2s-1,
+    obtained from the Gauss method by X = Xₛ + γ eₛ eₛᵀ.
+"""
+
+"""
+Tableau of two-stage, 3rd order fully implicit Runge-Kutta method
+
+```julia
+TableauIRK3(::Type{T}=Float64) where {T}
+```
+The constructor takes one optional argument, that is the element type of the tableau.
+
+The method uses the two-point Gauss-Legendre nodes and weights, but its coefficient matrix is
+that of [`TableauGauss`](@ref) plus the rank-one perturbation `¼ (e₁-e₂) (e₁-e₂)ᵀ`. It is
+therefore of order three rather than four and neither symmetric nor symplectic, but it is
+A-stable and algebraically stable with `R(∞) = -1/2`.
+
+$(reference(Val(:IRK3)))
+"""
+function TableauIRK3(::Type{T}=Float64) where {T}
+    a = @big [[ 1/2        -√3/6     ]
+              [+√3/6        1/2      ]]
+    b = @big  [ 1/2,        1/2      ]
+    c = @big  [ 1/2-√3/6,   1/2+√3/6 ]
+    o = 3
+
+    Tableau{T}(:IRK3, o, a, b, c; R∞=-1//2)
+end
+
+
 reference(::Val{:SRK3}) = """
 Reference:
 

--- a/test/test_tableaus.jl
+++ b/test/test_tableaus.jl
@@ -175,6 +175,29 @@ end
     @test issymplectic(TableauImplicitMidpoint())
     @test issymmetric(TableauImplicitMidpoint())
 
+    @test typeof(TableauIRK3()) <: Tableau
+    @test order(TableauIRK3()) == 3
+    @test nstages(TableauIRK3()) == 2
+    @test reference(TableauIRK3()) == reference(Val(:IRK3))
+    @test TableauIRK3().R∞ == -1//2
+
+    @test !isexplicit(TableauIRK3())
+    @test  isimplicit(TableauIRK3())
+    @test !isdiagonallyimplicit(TableauIRK3())
+    @test  isfullyimplicit(TableauIRK3())
+    @test !issymplectic(TableauIRK3())
+    @test !issymmetric(TableauIRK3())
+
+    # Gauss coefficients plus a rank-one perturbation, with the Gauss nodes and weights
+    let v = [1, -1]
+        @test coefficients(TableauIRK3()) ≈ coefficients(TableauGauss(2)) .+ v * v' ./ 4
+        @test weights(TableauIRK3()) ≈ weights(TableauGauss(2))
+        @test nodes(TableauIRK3()) ≈ nodes(TableauGauss(2))
+    end
+
+    # the Gauss nodes make the quadrature condition B(4) hold, even though the order is only three
+    @test RungeKutta.satisfies_simplifying_assumption_b(TableauIRK3(), 4)
+
     @test typeof(TableauSRK3()) <: Tableau
     @test order(TableauSRK3()) == 4
     @test nstages(TableauSRK3()) == 3


### PR DESCRIPTION
Adds `TableauIRK3`, a two-stage fully implicit Runge-Kutta tableau of order three.

```
0.211325 │      0.5  -0.288675
0.788675 │ 0.288675        0.5
─────────┼─────────────────────
         │      0.5        0.5
```

The tableau uses the two-point Gauss-Legendre nodes and weights, but its coefficient matrix is that of `TableauGauss(2)` plus the rank-one perturbation `¼ (e₁-e₂) (e₁-e₂)ᵀ`. It is therefore of order three rather than four and neither symmetric nor symplectic, but it is A-stable and algebraically stable (`M = BA + AᵀB - bbᵀ = ¼ vvᵀ ⪰ 0`) with `R(∞) = -1/2`.

In W-transformation coordinates the tableau is `X = [[1/2, -ξ₁], [ξ₁, 1/2]]` with `ξ₁ = 1/(2√3)`, i.e. the `s=2`, `γ=1/2` member of the family of algebraically stable methods of order `2s-1` obtained from the Gauss method by `X = Xₛ + γ eₛ eₛᵀ`, described in Hairer & Wanner, *Solving Ordinary Differential Equations II*, Section IV.5. That is the reference recorded in the docstring.

### Provenance

The tableau has been in use as a local definition in a script in [ChargedParticleDynamics.jl](https://github.com/JuliaPlasma/ChargedParticleDynamics.jl); this PR gives it a proper home. The local definition carried `c = [1/2, 1/2]`, which does not match the row sums of `a`. Since the problems it was applied to are autonomous, that never showed up, but it does reduce the method to order two on non-autonomous problems. The nodes here are the row sums, i.e. the Gauss nodes, so the method is genuinely third order:

| | rates over n = 20, 40, 80, 160 |
|---|---|
| `TableauIRK3`, autonomous test problem | 2.998, 2.999, 3.000 |
| `TableauIRK3`, non-autonomous test problem | 3.015, 3.007, 3.004 |
| same `a`/`b` but `c = [1/2, 1/2]`, non-autonomous | 2.010, 2.005, 2.002 |

### Changes

* `src/tableaus/firk.jl` — `reference(::Val{:IRK3})` and `TableauIRK3`
* `src/Tableaus.jl` — export and `TableauList` entry
* `test/test_tableaus.jl` — "Fully Implicit Tableaus" testset. Besides the usual order/stages/traits assertions, the coefficients are pinned to `TableauGauss(2)` plus the perturbation and `B(4)` is asserted; those two guard against a mis-parse of the whitespace-sensitive matrix literal and against the nodes drifting back to `[1/2, 1/2]`.
* `docs/src/methods.md`, `docs/src/index.md`, `README.md` — list the new tableau

Full test suite passes locally.