### PR TITLE
Normalise all sources to Unicode NFC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,26 +4,37 @@ All notable changes to RungeKutta.jl are documented here. Versions follow
 [semantic versioning](https://semver.org) as it applies to Julia's `0.x` series, where a
 change to the minor version may break compatibility.
 
-## Unreleased
+## [Unreleased] — targeting 0.6.2
 
 ### Changed
 
-- Every tracked source file is now Unicode NFC-normalised. Eleven files stored `ā` (34 times), `Ḡ`
-  (28), `Ē` (28), `Ā` (27), `â` (9), `ĉ` (9), `Ã` (6), `Â` (5), `é` (4) and `ã` (3) as a base letter
-  plus a combining mark, inherited from macOS rather than chosen.
+- Every tracked file is now Unicode NFC-normalised. Thirteen stored `ā` (38 times), `Ḡ` (28), `Ē`
+  (28), `Ā` (27), `â` (9), `ĉ` (9), `Ã` (6), `Â` (5), `é` (4) and `ã` (3) as a base letter plus a
+  combining mark, inherited from macOS rather than chosen. Eleven are `.jl`; the other two are the
+  Weave documents `docs/src/radau1.jmd` and `docs/src/radau2.jmd`, which `docs/make.jl` executes.
 
   Nothing about the compiled code changes: Julia's parser normalises identifiers to NFC, so the
   symbols were already precomposed and dispatch is untouched. What changes is that the source now
   matches what a keyboard, an editor search or a `grep` pattern produces — in an NFD file a pattern
   typed in NFC matches nothing at all, silently.
 
-  **One thing does change at runtime.** String literals are *not* parser-normalised, so
+  **Two kinds of string literal change at runtime**, since string literals are *not*
+  parser-normalised.
+
   `Symbol("LobattoIIIAIIIĀ", s)`, `Symbol("LobattoIIIEIIIĒ", s)` and `Symbol("LobattoIIIGIIIḠ", s)`
   in `src/tableaus/prk.jl` now produce precomposed symbols where they produced decomposed ones.
-  These are the `name` field of the returned `PartitionedTableau`, used for display; nothing in this
-  package or downstream compares them against a symbol written in source, so no result changes. Code
-  that did compare, having had to spell the name decomposed to match, would need the ordinary
-  spelling now.
+  These become the `name` field of the returned `PartitionedTableau` — shown, and also compared in
+  `Base.isequal` (`src/tableau_partitioned.jl:94`), though not in `==` or `hash`. Both operands
+  there are constructed at run time, so both are NFC and the comparison is unaffected. Nothing in
+  this package or downstream compares such a name against a symbol written in source, so no result
+  changes. Code that did compare, having had to spell the name decomposed to match, would need the
+  ordinary spelling now.
+
+  The `reference(::Val{…})` bodies in `src/tableaus/lobatto.jl` and `src/tableaus/radau.jl` also
+  change: `Padé` is now precomposed. `reference` is exported, so a caller sees the new bytes. The
+  tests compare `reference` against `reference` rather than against a literal
+  (`test/test_lobatto.jl:350`, `test/test_radau.jl:108–111`), and `Padé` appears nowhere else in
+  the tree.
 
   Note that the file looked mixed before — `Symbol("LobattoIIIBIIIB̄", s)` and its `C̄`, `D̄` and `F̄`
   siblings were already NFC — but that was not an inconsistency: a macron over `B`, `C`, `D` or `F`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to RungeKutta.jl are documented here. Versions follow
 [semantic versioning](https://semver.org) as it applies to Julia's `0.x` series, where a
 change to the minor version may break compatibility.
 
+## Unreleased
+
+### Changed
+
+- Every tracked source file is now Unicode NFC-normalised. Eleven files stored `ā` (34 times), `Ḡ`
+  (28), `Ē` (28), `Ā` (27), `â` (9), `ĉ` (9), `Ã` (6), `Â` (5), `é` (4) and `ã` (3) as a base letter
+  plus a combining mark, inherited from macOS rather than chosen.
+
+  Nothing about the compiled code changes: Julia's parser normalises identifiers to NFC, so the
+  symbols were already precomposed and dispatch is untouched. What changes is that the source now
+  matches what a keyboard, an editor search or a `grep` pattern produces — in an NFD file a pattern
+  typed in NFC matches nothing at all, silently.
+
+  **One thing does change at runtime.** String literals are *not* parser-normalised, so
+  `Symbol("LobattoIIIAIIIĀ", s)`, `Symbol("LobattoIIIEIIIĒ", s)` and `Symbol("LobattoIIIGIIIḠ", s)`
+  in `src/tableaus/prk.jl` now produce precomposed symbols where they produced decomposed ones.
+  These are the `name` field of the returned `PartitionedTableau`, used for display; nothing in this
+  package or downstream compares them against a symbol written in source, so no result changes. Code
+  that did compare, having had to spell the name decomposed to match, would need the ordinary
+  spelling now.
+
+  Note that the file looked mixed before — `Symbol("LobattoIIIBIIIB̄", s)` and its `C̄`, `D̄` and `F̄`
+  siblings were already NFC — but that was not an inconsistency: a macron over `B`, `C`, `D` or `F`
+  has no precomposed codepoint, so NFC leaves those decomposed and they are unchanged here.
+
 ## v0.6.1
 
 ### Fixed

--- a/docs/src/radau1.jmd
+++ b/docs/src/radau1.jmd
@@ -15,7 +15,7 @@ for s in 2:3
     a = radau_1_coefficients(symtype(),s)
     b = radau_legendre_weights(symtype(), s, Val(:left))
     c = radau_legendre_nodes(symtype(), s, Val(:left))
-    ā = symplectic_conjugate_coefficients(a,b)
-    show(stdout, "text/markdown", Tableau(Symbol("RadauIB($s)"), 2s-1, ā, b, c))
+    ā = symplectic_conjugate_coefficients(a,b)
+    show(stdout, "text/markdown", Tableau(Symbol("RadauIB($s)"), 2s-1, ā, b, c))
 end
 ```

--- a/docs/src/radau2.jmd
+++ b/docs/src/radau2.jmd
@@ -15,7 +15,7 @@ for s in 2:3
     a = radau_2_coefficients(symtype(),s)
     b = radau_legendre_weights(symtype(), s, Val(:right))
     c = radau_legendre_nodes(symtype(), s, Val(:right))
-    ā = symplectic_conjugate_coefficients(a,b)
-    show(stdout, "text/markdown", Tableau(Symbol("RadauIIB($s)"), 2s-1, ā, b, c))
+    ā = symplectic_conjugate_coefficients(a,b)
+    show(stdout, "text/markdown", Tableau(Symbol("RadauIIB($s)"), 2s-1, ā, b, c))
 end
 ```

--- a/src/PartitionedTableaus.jl
+++ b/src/PartitionedTableaus.jl
@@ -13,15 +13,15 @@ include("tableaus/prk.jl")
 
 export TableauLobattoIIIAIIIB,
        TableauLobattoIIIBIIIA,
-       TableauLobattoIIIAIIIĀ,
+       TableauLobattoIIIAIIIĀ,
        TableauLobattoIIIBIIIB̄,
        TableauLobattoIIICIIIC̄,
        TableauLobattoIIIC̄IIIC,
        TableauLobattoIIIDIIID̄,
-       TableauLobattoIIIEIIIĒ,
+       TableauLobattoIIIEIIIĒ,
        TableauLobattoIIIFIIIF̄,
        TableauLobattoIIIF̄IIIF,
-       TableauLobattoIIIGIIIḠ,
+       TableauLobattoIIIGIIIḠ,
        PartitionedTableauGauss
 
 PartitionedTableauList = (

--- a/src/Tableaus.jl
+++ b/src/Tableaus.jl
@@ -53,7 +53,7 @@ include("tableaus/lobatto.jl")
 
 export TableauLobattoIII,
        TableauLobattoIIIA,
-       TableauLobattoIIIĀ,
+       TableauLobattoIIIĀ,
        TableauLobattoIIIB,
        TableauLobattoIIIB̄,
        TableauLobattoIIIC,
@@ -61,11 +61,11 @@ export TableauLobattoIII,
        TableauLobattoIIID,
        TableauLobattoIIID̄,
        TableauLobattoIIIE,
-       TableauLobattoIIIĒ,
+       TableauLobattoIIIĒ,
        TableauLobattoIIIF,
        TableauLobattoIIIF̄,
        TableauLobattoIIIG,
-       TableauLobattoIIIḠ
+       TableauLobattoIIIḠ
 
 include("tableaus/radau.jl")
 

--- a/src/symplecticity.jl
+++ b/src/symplecticity.jl
@@ -11,9 +11,9 @@ end
 
 function check_symplecticity(tab::PartitionedTableau{T}; atol = 16eps(T), rtol = 16eps(T)) where {T}
     a, b = tab.q.a, tab.q.b
-    ā, b̄ = tab.p.a, tab.p.b
+    ā, b̄ = tab.p.a, tab.p.b
     (
-        [isapprox(b[i] * ā[i, j] + b̄[j] * a[j, i], b[i] * b̄[j]; atol = atol, rtol = rtol)
+        [isapprox(b[i] * ā[i, j] + b̄[j] * a[j, i], b[i] * b̄[j]; atol = atol, rtol = rtol)
          for i in axes(a, 1), j in axes(a, 2)],
         [isapprox(b[i], b̄[i]; atol = atol, rtol = rtol) for i in eachindex(b, b̄)])
 end

--- a/src/tableau.jl
+++ b/src/tableau.jl
@@ -53,15 +53,15 @@ struct Tableau{T, S, RT <: Union{Real, Missing}, L} <: AbstractTableau{T}
         @assert s > 0 "Number of stages must be > 0"
         @assert s == size(a, 1) == size(a, 2) == length(b) == length(c)
 
-        ã = SMatrix{s, s}(convert(Matrix{T}, a))
+        ã = SMatrix{s, s}(convert(Matrix{T}, a))
         b̃ = SVector{s}(convert(Vector{T}, b))
         c̃ = SVector{s}(convert(Vector{T}, c))
 
-        â = SMatrix{s, s}(a .- ã)
+        â = SMatrix{s, s}(a .- ã)
         b̂ = SVector{s}(b .- b̃)
         ĉ = SVector{s}(c .- c̃)
 
-        new{T, s, typeof(R∞), s * s}(name, o, s, ã, b̃, c̃, â, b̂, ĉ, R∞)
+        new{T, s, typeof(R∞), s * s}(name, o, s, ã, b̃, c̃, â, b̂, ĉ, R∞)
     end
 
     function Tableau{T}(name, o, a, b, c; kwargs...) where {T}
@@ -93,7 +93,7 @@ end
 function Base.hash(tab::Tableau, h::UInt)
     hash(tab.o,
         hash(tab.s,
-            hash(tab.a, hash(tab.b, hash(tab.c, hash(tab.â, hash(tab.b̂, hash(tab.ĉ, hash(:Tableau, h)))))))))
+            hash(tab.a, hash(tab.b, hash(tab.c, hash(tab.â, hash(tab.b̂, hash(tab.ĉ, hash(:Tableau, h)))))))))
 end
 
 function Base.:(==)(tab1::Tableau, tab2::Tableau)
@@ -102,9 +102,9 @@ function Base.:(==)(tab1::Tableau, tab2::Tableau)
      && tab1.a == tab2.a
      && tab1.b == tab2.b
      && tab1.c == tab2.c
-     && tab1.â == tab2.â
+     && tab1.â == tab2.â
      && tab1.b̂ == tab2.b̂
-     && tab1.ĉ == tab2.ĉ
+     && tab1.ĉ == tab2.ĉ
      && ((ismissing(tab1.R∞) && ismissing(tab2.R∞)) || (tab1.R∞ == tab2.R∞)))
 end
 

--- a/src/tableaus/lobatto.jl
+++ b/src/tableaus/lobatto.jl
@@ -134,8 +134,8 @@ end
 function lobatto_g_coefficients(::Type{T}, s) where {T}
     a = lobatto_f_coefficients(T, s)
     b = lobatto_legendre_weights(T, s)
-    ā = symplectic_conjugate_coefficients(a, b)
-    return (a .+ ā) ./ 2
+    ā = symplectic_conjugate_coefficients(a, b)
+    return (a .+ ā) ./ 2
 end
 
 lobatto_a_coefficients(s) = lobatto_a_coefficients(BigFloat, s)
@@ -187,7 +187,7 @@ function reference(::Val{:LobattoIIIA})
 References:
 
     Byron Leonard Ehle
-    On Padé approximations to the exponential function and a-stable methods for the numerical solution of initial value problems.
+    On Padé approximations to the exponential function and a-stable methods for the numerical solution of initial value problems.
     Research Report CSRR 2010, Dept. AACS, University of Waterloo, 1969.
 
     Laurent O. Jay.
@@ -215,25 +215,25 @@ function TableauLobattoIIIA(::Type{T}, s) where {T}
 end
 
 """
-Lobatto IIIĀ tableau with s stages
+Lobatto IIIĀ tableau with s stages
 
 ```julia
-TableauLobattoIIIĀ(::Type{T}, s)
-TableauLobattoIIIĀ(s) = TableauLobattoIIIĀ(Float64, s)
+TableauLobattoIIIĀ(::Type{T}, s)
+TableauLobattoIIIĀ(s) = TableauLobattoIIIĀ(Float64, s)
 ```
 The constructor takes the number of stages `s` and optionally the element type `T` of the tableau.
 
-Lobatto IIIĀ tableau is the conjugate symplectic to [`TableauLobattoIIIA`](@ref).
+Lobatto IIIĀ tableau is the conjugate symplectic to [`TableauLobattoIIIA`](@ref).
 On paper, its coefficients are identical to [`TableauLobattoIIIB`](@ref), however, they are computed
 by the symplecticity condition and not by the formula for Lobatto IIIB and thus the numerical
 values are slightly different.
 """
-function TableauLobattoIIIĀ(::Type{T}, s) where {T}
+function TableauLobattoIIIĀ(::Type{T}, s) where {T}
     a = lobatto_a_coefficients(s)
     b = lobatto_legendre_weights(BigFloat, s)
-    ā = symplectic_conjugate_coefficients(a, b)
+    ā = symplectic_conjugate_coefficients(a, b)
     Tableau{T}(
-        :LobattoIIIĀ, 2s-2, ā, b, lobatto_legendre_nodes(BigFloat, s); R∞ = (-1)^(s+1))
+        :LobattoIIIĀ, 2s-2, ā, b, lobatto_legendre_nodes(BigFloat, s); R∞ = (-1)^(s+1))
 end
 
 function reference(::Val{:LobattoIIIB})
@@ -241,7 +241,7 @@ function reference(::Val{:LobattoIIIB})
 References:
 
     Byron Leonard Ehle.
-    On Padé approximations to the exponential function and a-stable methods for the numerical solution of initial value problems.
+    On Padé approximations to the exponential function and a-stable methods for the numerical solution of initial value problems.
     Research Report CSRR 2010, Dept. AACS, University of Waterloo, 1969.
 
     Laurent O. Jay.
@@ -285,9 +285,9 @@ values are slightly different.
 function TableauLobattoIIIB̄(::Type{T}, s) where {T}
     a = lobatto_b_coefficients(s)
     b = lobatto_legendre_weights(BigFloat, s)
-    ā = symplectic_conjugate_coefficients(a, b)
+    ā = symplectic_conjugate_coefficients(a, b)
     Tableau{T}(
-        :LobattoIIIB̄, 2s-2, ā, b, lobatto_legendre_nodes(BigFloat, s); R∞ = (-1)^(s+1))
+        :LobattoIIIB̄, 2s-2, ā, b, lobatto_legendre_nodes(BigFloat, s); R∞ = (-1)^(s+1))
 end
 
 function reference(::Val{:LobattoIIIC})
@@ -340,9 +340,9 @@ values are slightly different.
 function TableauLobattoIIIC̄(::Type{T}, s) where {T}
     a = lobatto_c_coefficients(s)
     b = lobatto_legendre_weights(BigFloat, s)
-    ā = symplectic_conjugate_coefficients(a, b)
+    ā = symplectic_conjugate_coefficients(a, b)
     Tableau{T}(
-        :LobattoIIIC̄, 2s-2, ā, b, lobatto_legendre_nodes(BigFloat, s); R∞ = (-1)^(s+1))
+        :LobattoIIIC̄, 2s-2, ā, b, lobatto_legendre_nodes(BigFloat, s); R∞ = (-1)^(s+1))
 end
 
 function reference(::Val{:LobattoIIID})
@@ -395,8 +395,8 @@ and thus the numerical values are slightly different.
 function TableauLobattoIIID̄(::Type{T}, s) where {T}
     a = lobatto_d_coefficients(s)
     b = lobatto_legendre_weights(BigFloat, s)
-    ā = symplectic_conjugate_coefficients(a, b)
-    Tableau{T}(:LobattoIIID̄, 2s-2, ā, b, lobatto_legendre_nodes(BigFloat, s); R∞ = (-1)^s)
+    ā = symplectic_conjugate_coefficients(a, b)
+    Tableau{T}(:LobattoIIID̄, 2s-2, ā, b, lobatto_legendre_nodes(BigFloat, s); R∞ = (-1)^s)
 end
 
 function reference(::Val{:LobattoIIIE})
@@ -434,24 +434,24 @@ function TableauLobattoIIIE(::Type{T}, s) where {T}
 end
 
 """
-Lobatto IIIĒ tableau with s stages
+Lobatto IIIĒ tableau with s stages
 
 ```julia
-TableauLobattoIIIĒ(::Type{T}, s)
-TableauLobattoIIIĒ(s) = TableauLobattoIIIĒ(Float64, s)
+TableauLobattoIIIĒ(::Type{T}, s)
+TableauLobattoIIIĒ(s) = TableauLobattoIIIĒ(Float64, s)
 ```
 The constructor takes the number of stages `s` and optionally the element type `T` of the tableau.
 
-Lobatto IIIĒ tableau is the conjugate symplectic to [`TableauLobattoIIIE`](@ref).
-On paper, the coefficients of the Lobatto IIIE tableau are symplectic, however, the Lobatto IIIĒ
+Lobatto IIIĒ tableau is the conjugate symplectic to [`TableauLobattoIIIE`](@ref).
+On paper, the coefficients of the Lobatto IIIE tableau are symplectic, however, the Lobatto IIIĒ
 coefficients are computed by the symplecticity condition and not by the formula for Lobatto IIIE
 and thus the numerical values are slightly different.
 """
-function TableauLobattoIIIĒ(::Type{T}, s) where {T}
+function TableauLobattoIIIĒ(::Type{T}, s) where {T}
     a = lobatto_e_coefficients(s)
     b = lobatto_legendre_weights(BigFloat, s)
-    ā = symplectic_conjugate_coefficients(a, b)
-    Tableau{T}(:LobattoIIIĒ, 2s-2, ā, b, lobatto_legendre_nodes(BigFloat, s); R∞ = (-1)^s)
+    ā = symplectic_conjugate_coefficients(a, b)
+    Tableau{T}(:LobattoIIIĒ, 2s-2, ā, b, lobatto_legendre_nodes(BigFloat, s); R∞ = (-1)^s)
 end
 
 reference(::Val{:LobattoIIIF}) = """
@@ -493,8 +493,8 @@ The Lobatto IIIF̄ tableau is the conjugate symplectic to [`TableauLobattoIIIF`]
 function TableauLobattoIIIF̄(::Type{T}, s) where {T}
     a = lobatto_f_coefficients(s)
     b = lobatto_legendre_weights(BigFloat, s)
-    ā = symplectic_conjugate_coefficients(a, b)
-    Tableau{T}(:LobattoIIIF̄, 2s, ā, b, lobatto_legendre_nodes(BigFloat, s); R∞ = (-1)^s)
+    ā = symplectic_conjugate_coefficients(a, b)
+    Tableau{T}(:LobattoIIIF̄, 2s, ā, b, lobatto_legendre_nodes(BigFloat, s); R∞ = (-1)^s)
 end
 
 @doc raw"""
@@ -519,29 +519,29 @@ function TableauLobattoIIIG(::Type{T}, s) where {T}
 end
 
 """
-Lobatto IIIḠ tableau with s stages
+Lobatto IIIḠ tableau with s stages
 
 ```julia
-TableauLobattoIIIḠ(::Type{T}, s)
-TableauLobattoIIIḠ(s) = TableauLobattoIIIḠ(Float64, s)
+TableauLobattoIIIḠ(::Type{T}, s)
+TableauLobattoIIIḠ(s) = TableauLobattoIIIḠ(Float64, s)
 ```
 The constructor takes the number of stages `s` and optionally the element type `T` of the tableau.
 
-Lobatto IIIḠ tableau is the conjugate symplectic to [`TableauLobattoIIIG`](@ref).
-On paper, the coefficients of the Lobatto IIIG tableau are symplectic, however, the Lobatto IIIḠ
+Lobatto IIIḠ tableau is the conjugate symplectic to [`TableauLobattoIIIG`](@ref).
+On paper, the coefficients of the Lobatto IIIG tableau are symplectic, however, the Lobatto IIIḠ
 coefficients are computed by the symplecticity condition and not by the formula for Lobatto IIIG
 and thus the numerical values are slightly different.
 """
-function TableauLobattoIIIḠ(::Type{T}, s) where {T}
+function TableauLobattoIIIḠ(::Type{T}, s) where {T}
     a = lobatto_g_coefficients(s)
     b = lobatto_legendre_weights(BigFloat, s)
-    ā = symplectic_conjugate_coefficients(a, b)
-    Tableau{T}(:LobattoIIIḠ, 2s, ā, b, lobatto_legendre_nodes(BigFloat, s); R∞ = (-1)^s)
+    ā = symplectic_conjugate_coefficients(a, b)
+    Tableau{T}(:LobattoIIIḠ, 2s, ā, b, lobatto_legendre_nodes(BigFloat, s); R∞ = (-1)^s)
 end
 
 TableauLobattoIII(s) = TableauLobattoIII(Float64, s)
 TableauLobattoIIIA(s) = TableauLobattoIIIA(Float64, s)
-TableauLobattoIIIĀ(s) = TableauLobattoIIIĀ(Float64, s)
+TableauLobattoIIIĀ(s) = TableauLobattoIIIĀ(Float64, s)
 TableauLobattoIIIB(s) = TableauLobattoIIIB(Float64, s)
 TableauLobattoIIIB̄(s) = TableauLobattoIIIB̄(Float64, s)
 TableauLobattoIIIC(s) = TableauLobattoIIIC(Float64, s)
@@ -549,8 +549,8 @@ TableauLobattoIIIC̄(s) = TableauLobattoIIIC̄(Float64, s)
 TableauLobattoIIID(s) = TableauLobattoIIID(Float64, s)
 TableauLobattoIIID̄(s) = TableauLobattoIIID̄(Float64, s)
 TableauLobattoIIIE(s) = TableauLobattoIIIE(Float64, s)
-TableauLobattoIIIĒ(s) = TableauLobattoIIIĒ(Float64, s)
+TableauLobattoIIIĒ(s) = TableauLobattoIIIĒ(Float64, s)
 TableauLobattoIIIF(s) = TableauLobattoIIIF(Float64, s)
 TableauLobattoIIIF̄(s) = TableauLobattoIIIF̄(Float64, s)
 TableauLobattoIIIG(s) = TableauLobattoIIIG(Float64, s)
-TableauLobattoIIIḠ(s) = TableauLobattoIIIḠ(Float64, s)
+TableauLobattoIIIḠ(s) = TableauLobattoIIIḠ(Float64, s)

--- a/src/tableaus/prk.jl
+++ b/src/tableaus/prk.jl
@@ -9,7 +9,7 @@ PartitionedTableauGauss(s) = PartitionedTableauGauss(Float64, s)
 
 The constructor takes the number of stages `s` and optionally the element type `T` of the tableau.
 
-This [`PartitionedTableau`](@ref) uses [`TableauGauss`](@ref) for both coefficients `a` and `ā`.
+This [`PartitionedTableau`](@ref) uses [`TableauGauss`](@ref) for both coefficients `a` and `ā`.
 """
 function PartitionedTableauGauss(::Type{T}, s::Int) where {T}
     PartitionedTableau(Symbol("PGauss", s), TableauGauss(T, s))
@@ -27,7 +27,7 @@ TableauLobattoIIIAIIIB(s) = TableauLobattoIIIAIIIB(Float64, s)
 
 The constructor takes the number of stages `s` and optionally the element type `T` of the tableau.
 
-This [`PartitionedTableau`](@ref) uses [`TableauLobattoIIIA`](@ref) for `a` and [`TableauLobattoIIIB`](@ref) for `ā`.
+This [`PartitionedTableau`](@ref) uses [`TableauLobattoIIIA`](@ref) for `a` and [`TableauLobattoIIIB`](@ref) for `ā`.
 """
 function TableauLobattoIIIAIIIB(::Type{T}, s::Int) where {T}
     PartitionedTableau(Symbol("LobattoIIIAIIIB", s), TableauLobattoIIIA(T, s),
@@ -44,7 +44,7 @@ TableauLobattoIIIBIIIA(s) = TableauLobattoIIIBIIIA(Float64, s)
 
 The constructor takes the number of stages `s` and optionally the element type `T` of the tableau.
 
-This [`PartitionedTableau`](@ref) uses [`TableauLobattoIIIB`](@ref) for `a` and [`TableauLobattoIIIA`](@ref) for `ā`.
+This [`PartitionedTableau`](@ref) uses [`TableauLobattoIIIB`](@ref) for `a` and [`TableauLobattoIIIA`](@ref) for `ā`.
 """
 function TableauLobattoIIIBIIIA(::Type{T}, s::Int) where {T}
     PartitionedTableau(Symbol("LobattoIIIBIIIA", s), TableauLobattoIIIB(T, s),
@@ -52,20 +52,20 @@ function TableauLobattoIIIBIIIA(::Type{T}, s::Int) where {T}
 end
 
 """
-Tableau for Gauss-Lobatto IIIA-IIIĀ method with s stages
+Tableau for Gauss-Lobatto IIIA-IIIĀ method with s stages
 
 ```julia
-TableauLobattoIIIAIIIĀ(::Type{T}, s)
-TableauLobattoIIIAIIIĀ(s) = TableauLobattoIIIAIIIĀ(Float64, s)
+TableauLobattoIIIAIIIĀ(::Type{T}, s)
+TableauLobattoIIIAIIIĀ(s) = TableauLobattoIIIAIIIĀ(Float64, s)
 ```
 
 The constructor takes the number of stages `s` and optionally the element type `T` of the tableau.
 
-This [`PartitionedTableau`](@ref) uses [`TableauLobattoIIIA`](@ref) for `a` and [`TableauLobattoIIIĀ`](@ref) for `ā`.
+This [`PartitionedTableau`](@ref) uses [`TableauLobattoIIIA`](@ref) for `a` and [`TableauLobattoIIIĀ`](@ref) for `ā`.
 """
-function TableauLobattoIIIAIIIĀ(::Type{T}, s::Int) where {T}
-    PartitionedTableau(Symbol("LobattoIIIAIIIĀ", s), TableauLobattoIIIA(T, s),
-        TableauLobattoIIIĀ(T, s); R∞ = (-1)^(s+1))
+function TableauLobattoIIIAIIIĀ(::Type{T}, s::Int) where {T}
+    PartitionedTableau(Symbol("LobattoIIIAIIIĀ", s), TableauLobattoIIIA(T, s),
+        TableauLobattoIIIĀ(T, s); R∞ = (-1)^(s+1))
 end
 
 """
@@ -78,7 +78,7 @@ TableauLobattoIIIBIIIB̄(s) = TableauLobattoIIIBIIIB̄(Float64, s)
 
 The constructor takes the number of stages `s` and optionally the element type `T` of the tableau.
 
-This [`PartitionedTableau`](@ref) uses [`TableauLobattoIIIB`](@ref) for `a` and [`TableauLobattoIIIB̄`](@ref) for `ā`.
+This [`PartitionedTableau`](@ref) uses [`TableauLobattoIIIB`](@ref) for `a` and [`TableauLobattoIIIB̄`](@ref) for `ā`.
 """
 function TableauLobattoIIIBIIIB̄(::Type{T}, s::Int) where {T}
     PartitionedTableau(Symbol("LobattoIIIBIIIB̄", s), TableauLobattoIIIB(T, s),
@@ -95,7 +95,7 @@ TableauLobattoIIICIIIC̄(s) = TableauLobattoIIICIIIC̄(Float64, s)
 
 The constructor takes the number of stages `s` and optionally the element type `T` of the tableau.
 
-This [`PartitionedTableau`](@ref) uses [`TableauLobattoIIIC`](@ref) for `a` and [`TableauLobattoIIIC̄`](@ref) for `ā`.
+This [`PartitionedTableau`](@ref) uses [`TableauLobattoIIIC`](@ref) for `a` and [`TableauLobattoIIIC̄`](@ref) for `ā`.
 """
 function TableauLobattoIIICIIIC̄(::Type{T}, s::Int) where {T}
     PartitionedTableau(Symbol("LobattoIIICIIIC̄", s), TableauLobattoIIIC(T, s),
@@ -112,7 +112,7 @@ TableauLobattoIIIC̄IIIC(s) = TableauLobattoIIIC̄IIIC(Float64, s)
 
 The constructor takes the number of stages `s` and optionally the element type `T` of the tableau.
 
-This [`PartitionedTableau`](@ref) uses [`TableauLobattoIIIC̄`](@ref) for `a` and [`TableauLobattoIIIC`](@ref) for `ā`.
+This [`PartitionedTableau`](@ref) uses [`TableauLobattoIIIC̄`](@ref) for `a` and [`TableauLobattoIIIC`](@ref) for `ā`.
 """
 function TableauLobattoIIIC̄IIIC(::Type{T}, s::Int) where {T}
     PartitionedTableau(Symbol("LobattoIIIC̄IIIC", s), TableauLobattoIIIC̄(T, s),
@@ -129,7 +129,7 @@ TableauLobattoIIIDIIID̄(s) = TableauLobattoIIIDIIID̄(Float64, s)
 
 The constructor takes the number of stages `s` and optionally the element type `T` of the tableau.
 
-This [`PartitionedTableau`](@ref) uses [`TableauLobattoIIID`](@ref) for `a` and [`TableauLobattoIIID̄`](@ref) for `ā`.
+This [`PartitionedTableau`](@ref) uses [`TableauLobattoIIID`](@ref) for `a` and [`TableauLobattoIIID̄`](@ref) for `ā`.
 """
 function TableauLobattoIIIDIIID̄(::Type{T}, s::Int) where {T}
     PartitionedTableau(Symbol("LobattoIIIDIIID̄", s), TableauLobattoIIID(T, s),
@@ -137,20 +137,20 @@ function TableauLobattoIIIDIIID̄(::Type{T}, s::Int) where {T}
 end
 
 """
-Tableau for Gauss-Lobatto IIIE-IIIĒ method with s stages
+Tableau for Gauss-Lobatto IIIE-IIIĒ method with s stages
 
 ```julia
-TableauLobattoIIIEIIIĒ(::Type{T}, s)
-TableauLobattoIIIEIIIĒ(s) = TableauLobattoIIIEIIIĒ(Float64, s)
+TableauLobattoIIIEIIIĒ(::Type{T}, s)
+TableauLobattoIIIEIIIĒ(s) = TableauLobattoIIIEIIIĒ(Float64, s)
 ```
 
 The constructor takes the number of stages `s` and optionally the element type `T` of the tableau.
 
-This [`PartitionedTableau`](@ref) uses [`TableauLobattoIIIE`](@ref) for `a` and [`TableauLobattoIIIĒ`](@ref) for `ā`.
+This [`PartitionedTableau`](@ref) uses [`TableauLobattoIIIE`](@ref) for `a` and [`TableauLobattoIIIĒ`](@ref) for `ā`.
 """
-function TableauLobattoIIIEIIIĒ(::Type{T}, s::Int) where {T}
-    PartitionedTableau(Symbol("LobattoIIIEIIIĒ", s), TableauLobattoIIIE(T, s),
-        TableauLobattoIIIĒ(T, s); R∞ = (-1)^s)
+function TableauLobattoIIIEIIIĒ(::Type{T}, s::Int) where {T}
+    PartitionedTableau(Symbol("LobattoIIIEIIIĒ", s), TableauLobattoIIIE(T, s),
+        TableauLobattoIIIĒ(T, s); R∞ = (-1)^s)
 end
 
 """
@@ -163,7 +163,7 @@ TableauLobattoIIIFIIIF̄(s) = TableauLobattoIIIFIIIF̄(Float64, s)
 
 The constructor takes the number of stages `s` and optionally the element type `T` of the tableau.
 
-This [`PartitionedTableau`](@ref) uses [`TableauLobattoIIIF`](@ref) for `a` and [`TableauLobattoIIIF̄`](@ref) for `ā`.
+This [`PartitionedTableau`](@ref) uses [`TableauLobattoIIIF`](@ref) for `a` and [`TableauLobattoIIIF̄`](@ref) for `ā`.
 """
 function TableauLobattoIIIFIIIF̄(::Type{T}, s::Int) where {T}
     PartitionedTableau(Symbol("LobattoIIIFIIIF̄", s), TableauLobattoIIIF(T, s),
@@ -180,7 +180,7 @@ TableauLobattoIIIF̄IIIF(s) = TableauLobattoIIIF̄IIIF(Float64, s)
 
 The constructor takes the number of stages `s` and optionally the element type `T` of the tableau.
 
-This [`PartitionedTableau`](@ref) uses [`TableauLobattoIIIF̄`](@ref) for `a` and [`TableauLobattoIIIF`](@ref) for `ā`.
+This [`PartitionedTableau`](@ref) uses [`TableauLobattoIIIF̄`](@ref) for `a` and [`TableauLobattoIIIF`](@ref) for `ā`.
 """
 function TableauLobattoIIIF̄IIIF(::Type{T}, s::Int) where {T}
     PartitionedTableau(Symbol("LobattoIIIF̄IIIF", s), TableauLobattoIIIF̄(T, s),
@@ -188,30 +188,30 @@ function TableauLobattoIIIF̄IIIF(::Type{T}, s::Int) where {T}
 end
 
 """
-Tableau for Gauss-Lobatto IIIG-IIIḠ method with s stages
+Tableau for Gauss-Lobatto IIIG-IIIḠ method with s stages
 
 ```julia
-TableauLobattoIIIGIIIḠ(::Type{T}, s)
-TableauLobattoIIIGIIIḠ(s) = TableauLobattoIIIGIIIḠ(Float64, s)
+TableauLobattoIIIGIIIḠ(::Type{T}, s)
+TableauLobattoIIIGIIIḠ(s) = TableauLobattoIIIGIIIḠ(Float64, s)
 ```
 
 The constructor takes the number of stages `s` and optionally the element type `T` of the tableau.
 
-This [`PartitionedTableau`](@ref) uses [`TableauLobattoIIIG`](@ref) for `a` and [`TableauLobattoIIIḠ`](@ref) for `ā`.
+This [`PartitionedTableau`](@ref) uses [`TableauLobattoIIIG`](@ref) for `a` and [`TableauLobattoIIIḠ`](@ref) for `ā`.
 """
-function TableauLobattoIIIGIIIḠ(::Type{T}, s::Int) where {T}
-    PartitionedTableau(Symbol("LobattoIIIGIIIḠ", s), TableauLobattoIIIG(T, s),
-        TableauLobattoIIIḠ(T, s); R∞ = (-1)^s)
+function TableauLobattoIIIGIIIḠ(::Type{T}, s::Int) where {T}
+    PartitionedTableau(Symbol("LobattoIIIGIIIḠ", s), TableauLobattoIIIG(T, s),
+        TableauLobattoIIIḠ(T, s); R∞ = (-1)^s)
 end
 
 TableauLobattoIIIAIIIB(s) = TableauLobattoIIIAIIIB(Float64, s)
 TableauLobattoIIIBIIIA(s) = TableauLobattoIIIBIIIA(Float64, s)
-TableauLobattoIIIAIIIĀ(s) = TableauLobattoIIIAIIIĀ(Float64, s)
+TableauLobattoIIIAIIIĀ(s) = TableauLobattoIIIAIIIĀ(Float64, s)
 TableauLobattoIIIBIIIB̄(s) = TableauLobattoIIIBIIIB̄(Float64, s)
 TableauLobattoIIICIIIC̄(s) = TableauLobattoIIICIIIC̄(Float64, s)
 TableauLobattoIIIC̄IIIC(s) = TableauLobattoIIIC̄IIIC(Float64, s)
 TableauLobattoIIIDIIID̄(s) = TableauLobattoIIIDIIID̄(Float64, s)
-TableauLobattoIIIEIIIĒ(s) = TableauLobattoIIIEIIIĒ(Float64, s)
+TableauLobattoIIIEIIIĒ(s) = TableauLobattoIIIEIIIĒ(Float64, s)
 TableauLobattoIIIFIIIF̄(s) = TableauLobattoIIIFIIIF̄(Float64, s)
 TableauLobattoIIIF̄IIIF(s) = TableauLobattoIIIF̄IIIF(Float64, s)
-TableauLobattoIIIGIIIḠ(s) = TableauLobattoIIIGIIIḠ(Float64, s)
+TableauLobattoIIIGIIIḠ(s) = TableauLobattoIIIGIIIḠ(Float64, s)

--- a/src/tableaus/radau.jl
+++ b/src/tableaus/radau.jl
@@ -35,7 +35,7 @@ function reference(::Val{:RadauIA})
 References:
 
     Byron Leonard Ehle
-    On Padé approximations to the exponential function and a-stable methods for the numerical solution of initial value problems.
+    On Padé approximations to the exponential function and a-stable methods for the numerical solution of initial value problems.
     Research Report CSRR 2010, Dept. AACS, University of Waterloo, 1969.
 """
 end
@@ -93,9 +93,9 @@ $(reference(Val(:RadauIB)))
 function TableauRadauIB(::Type{T}, s) where {T}
     a = radau_1_coefficients(BigFloat, s)
     b = radau_legendre_weights(BigFloat, s, Val(:left))
-    ā = symplectic_conjugate_coefficients(a, b)
+    ā = symplectic_conjugate_coefficients(a, b)
 
-    Tableau{T}(:RadauIB, 2s-1, (a .+ ā) ./ 2, b,
+    Tableau{T}(:RadauIB, 2s-1, (a .+ ā) ./ 2, b,
         radau_legendre_nodes(BigFloat, s, Val(:left)); R∞ = 0)
 end
 
@@ -106,7 +106,7 @@ function reference(::Val{:RadauIIA})
 References:
 
     Byron Leonard Ehle
-    On Padé approximations to the exponential function and a-stable methods for the numerical solution of initial value problems.
+    On Padé approximations to the exponential function and a-stable methods for the numerical solution of initial value problems.
     Research Report CSRR 2010, Dept. AACS, University of Waterloo, 1969.
 
     Owe Axelsson.
@@ -175,9 +175,9 @@ $(reference(Val(:RadauIIB)))
 function TableauRadauIIB(::Type{T}, s) where {T}
     a = radau_2_coefficients(BigFloat, s)
     b = radau_legendre_weights(BigFloat, s, Val(:right))
-    ā = symplectic_conjugate_coefficients(a, b)
+    ā = symplectic_conjugate_coefficients(a, b)
 
-    Tableau{T}(:RadauIIB, 2s-1, (a .+ ā) ./ 2, b,
+    Tableau{T}(:RadauIIB, 2s-1, (a .+ ā) ./ 2, b,
         radau_legendre_nodes(BigFloat, s, Val(:right)); R∞ = 0)
 end
 

--- a/test/test_lobatto.jl
+++ b/test/test_lobatto.jl
@@ -289,7 +289,7 @@ using RungeKutta.Tableaus: lobatto_nullvector,
 
     @test_throws ErrorException TableauLobattoIII(1)
     @test_throws ErrorException TableauLobattoIIIA(1)
-    @test_throws ErrorException TableauLobattoIIIĀ(1)
+    @test_throws ErrorException TableauLobattoIIIĀ(1)
     @test_throws ErrorException TableauLobattoIIIB(1)
     @test_throws ErrorException TableauLobattoIIIB̄(1)
     @test_throws ErrorException TableauLobattoIIIC(1)
@@ -297,11 +297,11 @@ using RungeKutta.Tableaus: lobatto_nullvector,
     @test_throws ErrorException TableauLobattoIIID(1)
     @test_throws ErrorException TableauLobattoIIID̄(1)
     @test_throws ErrorException TableauLobattoIIIE(1)
-    @test_throws ErrorException TableauLobattoIIIĒ(1)
+    @test_throws ErrorException TableauLobattoIIIĒ(1)
     @test_throws ErrorException TableauLobattoIIIF(1)
     @test_throws ErrorException TableauLobattoIIIF̄(1)
     @test_throws ErrorException TableauLobattoIIIG(1)
-    @test_throws ErrorException TableauLobattoIIIḠ(1)
+    @test_throws ErrorException TableauLobattoIIIḠ(1)
 
     @test TableauLobattoIII(2) ≈ _getTableauLobattoIIIC̄2()
     @test TableauLobattoIII(3) ≈ _getTableauLobattoIIIC̄3()
@@ -356,10 +356,10 @@ using RungeKutta.Tableaus: lobatto_nullvector,
 
     for s in 2:5
         @test TableauLobattoIIIA(s) ≈ TableauLobattoIIIB̄(s)
-        @test TableauLobattoIIIB(s) ≈ TableauLobattoIIIĀ(s)
+        @test TableauLobattoIIIB(s) ≈ TableauLobattoIIIĀ(s)
         @test TableauLobattoIIID(s) ≈ TableauLobattoIIID̄(s)
-        @test TableauLobattoIIIE(s) ≈ TableauLobattoIIIĒ(s)
-        @test TableauLobattoIIIG(s) ≈ TableauLobattoIIIḠ(s)
+        @test TableauLobattoIIIE(s) ≈ TableauLobattoIIIĒ(s)
+        @test TableauLobattoIIIG(s) ≈ TableauLobattoIIIḠ(s)
 
         @test !issymplectic(TableauLobattoIII(s))
         @test !issymplectic(TableauLobattoIIIA(s))

--- a/test/test_symplecticity.jl
+++ b/test/test_symplecticity.jl
@@ -19,30 +19,30 @@
     for s in 2:10
         A = TableauLobattoIIIA(s)
         B = TableauLobattoIIIB(s)
-        Ã = SymplecticConjugateTableau(A)
+        Ã = SymplecticConjugateTableau(A)
         B̃ = SymplecticConjugateTableau(B)
 
         @test A.a ≈ B̃.a atol=1E-15
-        @test A.b == Ã.b
-        @test A.c == Ã.c
+        @test A.b == Ã.b
+        @test A.c == Ã.c
 
-        @test B.a ≈ Ã.a atol=1E-15
-        @test B.b == Ã.b
-        @test B.c == Ã.c
+        @test B.a ≈ Ã.a atol=1E-15
+        @test B.b == Ã.b
+        @test B.c == Ã.c
 
-        Â = SymplecticTableau(A)
+        Â = SymplecticTableau(A)
         B̂ = SymplecticTableau(B)
         E = TableauLobattoIIIE(s)
 
-        @test Â.a ≈ E.a atol=1E-15
-        @test Â.b == E.b
-        @test Â.c == E.c
+        @test Â.a ≈ E.a atol=1E-15
+        @test Â.b == E.b
+        @test Â.c == E.c
 
         @test B̂.a ≈ E.a atol=1E-15
         @test B̂.b == E.b
         @test B̂.c == E.c
 
-        @test issymplectic(Â)
+        @test issymplectic(Â)
         @test issymplectic(B̂)
         @test issymplectic(E)
         @test issymplectic(SymplecticPartitionedTableau(A))

--- a/test/test_tableau.jl
+++ b/test/test_tableau.jl
@@ -69,9 +69,9 @@ import QuadratureRules
             @test tab1.b == tab2.b == tab3.b == tab4.b == b
             @test tab1.c == tab2.c == tab3.c == tab4.c == c
 
-            @test tab1.â == tab2.â == tab3.â == tab4.â == zero(a)
+            @test tab1.â == tab2.â == tab3.â == tab4.â == zero(a)
             @test tab1.b̂ == tab2.b̂ == tab3.b̂ == tab4.b̂ == zero(b)
-            @test tab1.ĉ == tab2.ĉ == tab3.ĉ == tab4.ĉ == zero(c)
+            @test tab1.ĉ == tab2.ĉ == tab3.ĉ == tab4.ĉ == zero(c)
 
             @test tab1 == Tableau(tab1.name, tab1.o, to_array(tab1))
             @test tab1 == Tableau(tab1.name, tab1.o, convert(Matrix, tab1))
@@ -97,9 +97,9 @@ import QuadratureRules
         tab1 = Tableau{T1}(:Test, 2s, s, a, b, c)
         tab2 = Tableau{T2}(:Test, 2s, s, a, b, c)
 
-        @test tab2.â == T2.(tab1.a .- tab2.a)
+        @test tab2.â == T2.(tab1.a .- tab2.a)
         @test tab2.b̂ == T2.(tab1.b .- tab2.b)
-        @test tab2.ĉ == T2.(tab1.c .- tab2.c)
+        @test tab2.ĉ == T2.(tab1.c .- tab2.c)
 
         tmp = mktempdir()
         to_file(tmp, tab2)

--- a/test/test_tableaus_prk.jl
+++ b/test/test_tableaus_prk.jl
@@ -46,8 +46,8 @@ using RungeKutta: name, order, nstages, coefficients, weights, nodes
     @test typeof(TableauLobattoIIIAIIIB(3)) <: PartitionedTableau
     @test typeof(TableauLobattoIIIBIIIA(2)) <: PartitionedTableau
     @test typeof(TableauLobattoIIIBIIIA(3)) <: PartitionedTableau
-    @test typeof(TableauLobattoIIIAIIIĀ(2)) <: PartitionedTableau
-    @test typeof(TableauLobattoIIIAIIIĀ(3)) <: PartitionedTableau
+    @test typeof(TableauLobattoIIIAIIIĀ(2)) <: PartitionedTableau
+    @test typeof(TableauLobattoIIIAIIIĀ(3)) <: PartitionedTableau
     @test typeof(TableauLobattoIIIBIIIB̄(2)) <: PartitionedTableau
     @test typeof(TableauLobattoIIIBIIIB̄(3)) <: PartitionedTableau
     @test typeof(TableauLobattoIIICIIIC̄(2)) <: PartitionedTableau
@@ -56,26 +56,26 @@ using RungeKutta: name, order, nstages, coefficients, weights, nodes
     @test typeof(TableauLobattoIIIC̄IIIC(3)) <: PartitionedTableau
     @test typeof(TableauLobattoIIIDIIID̄(2)) <: PartitionedTableau
     @test typeof(TableauLobattoIIIDIIID̄(3)) <: PartitionedTableau
-    @test typeof(TableauLobattoIIIEIIIĒ(2)) <: PartitionedTableau
-    @test typeof(TableauLobattoIIIEIIIĒ(3)) <: PartitionedTableau
+    @test typeof(TableauLobattoIIIEIIIĒ(2)) <: PartitionedTableau
+    @test typeof(TableauLobattoIIIEIIIĒ(3)) <: PartitionedTableau
     @test typeof(TableauLobattoIIIFIIIF̄(2)) <: PartitionedTableau
     @test typeof(TableauLobattoIIIFIIIF̄(3)) <: PartitionedTableau
     @test typeof(TableauLobattoIIIF̄IIIF(2)) <: PartitionedTableau
     @test typeof(TableauLobattoIIIF̄IIIF(3)) <: PartitionedTableau
-    @test typeof(TableauLobattoIIIGIIIḠ(2)) <: PartitionedTableau
-    @test typeof(TableauLobattoIIIGIIIḠ(3)) <: PartitionedTableau
+    @test typeof(TableauLobattoIIIGIIIḠ(2)) <: PartitionedTableau
+    @test typeof(TableauLobattoIIIGIIIḠ(3)) <: PartitionedTableau
 
     @test TableauLobattoIIIAIIIB(2) == TableauLobattoIIIAIIIB(Float64, 2)
     @test TableauLobattoIIIBIIIA(2) == TableauLobattoIIIBIIIA(Float64, 2)
-    @test TableauLobattoIIIAIIIĀ(2) == TableauLobattoIIIAIIIĀ(Float64, 2)
+    @test TableauLobattoIIIAIIIĀ(2) == TableauLobattoIIIAIIIĀ(Float64, 2)
     @test TableauLobattoIIIBIIIB̄(2) == TableauLobattoIIIBIIIB̄(Float64, 2)
     @test TableauLobattoIIICIIIC̄(2) == TableauLobattoIIICIIIC̄(Float64, 2)
     @test TableauLobattoIIIC̄IIIC(2) == TableauLobattoIIIC̄IIIC(Float64, 2)
     @test TableauLobattoIIIDIIID̄(2) == TableauLobattoIIIDIIID̄(Float64, 2)
-    @test TableauLobattoIIIEIIIĒ(2) == TableauLobattoIIIEIIIĒ(Float64, 2)
+    @test TableauLobattoIIIEIIIĒ(2) == TableauLobattoIIIEIIIĒ(Float64, 2)
     @test TableauLobattoIIIFIIIF̄(2) == TableauLobattoIIIFIIIF̄(Float64, 2)
     @test TableauLobattoIIIF̄IIIF(2) == TableauLobattoIIIF̄IIIF(Float64, 2)
-    @test TableauLobattoIIIGIIIḠ(2) == TableauLobattoIIIGIIIḠ(Float64, 2)
+    @test TableauLobattoIIIGIIIḠ(2) == TableauLobattoIIIGIIIḠ(Float64, 2)
 
     @test order(TableauLobattoIIIAIIIB(2)) == 2
     @test order(TableauLobattoIIIAIIIB(3)) == 4


### PR DESCRIPTION
Converts thirteen tracked files from NFD to Unicode NFC. They stored `ā` (38×), `Ḡ` (28), `Ē` (28), `Ā` (27), `â` (9), `ĉ` (9), `Ã` (6), `Â` (5), `é` (4) and `ã` (3) as a base letter plus a combining mark — an artefact of macOS, not a decision.

Eleven are `.jl`; the other two are the Weave documents `docs/src/radau1.jmd` and `docs/src/radau2.jmd`, which `docs/make.jl:66,71` execute.

Part of a tree-wide conversion (`Tasks/Normalise the Julia sources to NFC.md`).

## Why

Julia's parser normalises identifiers to NFC, so the compiled symbols were already precomposed and dispatch is untouched. The cost of NFD is entirely in tooling: **a pattern typed in NFC matches nothing at all in an NFD file, silently.**

`B̄`, `C̄`, `D̄`, `F̄` and the other macron- or circumflex-over-consonant sequences have **no precomposed codepoint** and are genuinely unchanged. That is also why `prk.jl` looked mixed before — `Symbol("LobattoIIIBIIIB̄", s)` was already NFC while `…IIIĀ` was not. Not an inconsistency: the invariant is `s == Unicode.normalize(s, :NFC)`, not the absence of combining marks.

## Two kinds of string literal change at runtime

String literals are *not* parser-normalised.

**1. Three tableau names.** `Symbol("LobattoIIIAIIIĀ", s)`, `…IIIEIIIĒ…` and `…IIIGIIIḠ…` at `src/tableaus/prk.jl:67,152,203` now build precomposed symbols. These become the `name` field of the returned `PartitionedTableau` — shown, and also compared in `Base.isequal` (`src/tableau_partitioned.jl:94`), though not in `==` or `hash`. Both operands there are constructed at run time, so both are NFC.

A **dual-normalisation search** — each name in both its NFC and NFD spelling, since a pattern typed in NFC cannot match an NFD occurrence — across `~/Research/Packages` and `~/Research/Experiments` finds no comparison of these names against a symbol written in source. Every hit is an identifier, a `struct` name or a Documenter `@ref`.

**2. Four bibliography strings.** The `reference(::Val{…})` bodies at `src/tableaus/lobatto.jl:190,244` and `src/tableaus/radau.jl:38,109` now spell `Padé` precomposed. `reference` is exported, so a caller sees the new bytes. The tests compare `reference` against `reference`, never against a literal (`test/test_lobatto.jl:350`, `test/test_radau.jl:108–111`), and `Padé` appears nowhere else in the tree.

## How to review

Each changed file is byte-equal to the NFC normalisation of its predecessor. `Meta.parseall` differs in only 3 of 11 `.jl` files, and **every difference is a docstring, a `reference` body, or one of those three names** — no method name, argument type or type parameter is touched.

## Verification

| what | result |
|:--|:--|
| diff is exactly the NFC normalisation | 13/13 files |
| `Pkg.test()` | **2932 passed, 0 failed** |
| glyph counts | all ten exact, and the list is complete |
| non-NFC tracked files remaining | **0 of 58** |
| `Symbol` / `Char` / `Val{:…}` / Dict / NamedTuple keys used for dispatch or lookup | none — the three `Symbol(…)` tableau names in §1 do change bytes, but nothing matches them against a symbol written in source |
| `jldoctest` or `@example` blocks in the repository | none at all |
| `fatou lint` | 16 findings, **0** inside the changed-line set |

**Not applicable** rather than unmeasured: piracy, inference, allocations — the parse-tree differences are confined to string contents.

## Pre-PR verification

Two defects in my changelog entry were found and fixed in a follow-up commit, one of them substantive:

- The entry claimed *every tracked source file* was NFC. **It was not.** The two `.jmd` documents above were still decomposed, because the converter defaulted to a `.jl`/`.md`/`.toml` whitelist and never looked at `.jmd`. The tool is now extension-agnostic — it takes every tracked file that is valid UTF-8 — and those two files are converted here.
- The runtime section named only the three `Symbol` calls and missed the four `Padé` strings.

